### PR TITLE
Modifies the makefiles to fix hardcoding of the gcc binary

### DIFF
--- a/AvunaDNS/Debug/makefile
+++ b/AvunaDNS/Debug/makefile
@@ -29,7 +29,7 @@ all: AvunaDNSD
 AvunaDNSD: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C Linker'
-	gcc  -o "AvunaDNSD" $(OBJS) $(USER_OBJS) $(LIBS)
+	$(CC)  -o "AvunaDNSD" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/AvunaDNS/Debug/makefile
+++ b/AvunaDNS/Debug/makefile
@@ -29,7 +29,7 @@ all: AvunaDNSD
 AvunaDNSD: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C Linker'
-	$(CC)  -o "AvunaDNSD" $(OBJS) $(USER_OBJS) $(LIBS)
+	$(CC) $(CFLAGS)  -o "AvunaDNSD" $(OBJS) $(USER_OBJS) $(LDFLAGS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/AvunaDNS/Debug/src/subdir.mk
+++ b/AvunaDNS/Debug/src/subdir.mk
@@ -50,7 +50,7 @@ C_DEPS += \
 src/%.o: ../src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C Compiler'
-	$(CC) -std=gnu11 -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CC) $(CFLAGS) -std=gnu11 -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/AvunaDNS/Debug/src/subdir.mk
+++ b/AvunaDNS/Debug/src/subdir.mk
@@ -50,7 +50,7 @@ C_DEPS += \
 src/%.o: ../src/%.c
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C Compiler'
-	gcc -std=gnu11 -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CC) -std=gnu11 -O0 -g3 -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/AvunaDNS/main.cfg
+++ b/AvunaDNS/main.cfg
@@ -1,7 +1,7 @@
 [daemon]
 uid = 0
 pid = 0
-pid-file = /var/run/avuna/dnsd.pid
+pid-file = /tmp/dnsd.pid
 
 [server main]
 bind-mode	= udp # or unix


### PR DESCRIPTION
This PR modifies the makefiles to change the hardcoded "gcc" values to the dynamic $(CC) variable.

This allows a developer to define a custom GCC binary, which is useful for cross compilation and using a custom toolchain instead of the system's GCC.
